### PR TITLE
Environment Variable Support + Small Fixes and Renaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,34 @@
-__pycache__/
-.vscode/
+# System files
 .DS_Store
 Thumbs.db
+
+# Development artifacts
+__pycache__/
 *.egg-info/
+dist/
+build/
 docs/_build/
-.env*
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
 instance/
 .pytest_cache/
 .coverage
-dist/
-build/
-static/
-config.toml
 *.log
+
+# Virtual environments
+env/
+env.bak/
+venv/
+venv.bak/
+ENV/
+ENV.bak/
+.env/
+.env.bak/
+.venv/
+.venv.bak/
+
+# Tools and editor settings
+.vscode/
+.cspell/
+
+# Program files
+config.toml
+static/

--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
                     MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2024, mBaratta96
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ ascending = false
 [TMDB]
 api_key = "YOUR_TMDB_API_KEY"
 # When you get your lists (-L options), also get all the runtimes from TMDB
-# and compute the mean of the ratings weigthed on the durations. This slows the process.
+# and compute the mean of the ratings weighted on the durations. This slows the process.
 get_list_runtimes = false
 
 
@@ -64,7 +64,7 @@ options:
   -l LIMIT, --limit LIMIT
                         limit the number of items of your wishlist/diary
   -c CONFIG_FOLDER, --config_folder CONFIG_FOLDER
-                        Specifiy the folder of your config.toml file
+                        Specify the folder of your config.toml file
 
 ```
 

--- a/letterboxd_stats/__init__.py
+++ b/letterboxd_stats/__init__.py
@@ -25,8 +25,13 @@ def load_config(file_path, defaults):
     else:
         user_config = {}
 
-    # Merge user_config with defaults (user_config takes precedence)
-    return merge_dicts(defaults, user_config)
+    # Merge user_config with defaults
+    merged_config = merge_dicts(defaults, user_config)
+
+    # Override with environment variables if available
+    merged_config = apply_env_variables(merged_config)
+
+    return merged_config
 
 def merge_dicts(defaults, overrides):
     """Recursively merge two dictionaries."""
@@ -37,6 +42,33 @@ def merge_dicts(defaults, overrides):
         else:
             merged[key] = value
     return merged
+
+def apply_env_variables(config):
+    """Override configuration with environment variables."""
+    env_mapping = {
+        "LBSTATS_CLI_POSTER_COLUMNS": ("CLI", "poster_columns"),
+        "LBSTATS_CLI_ASCENDING": ("CLI", "ascending"),
+        "LBSTATS_TMDB_GET_LIST_RUNTIMES": ("TMDB", "get_list_runtimes"),
+        "LBSTATS_TMDB_API_KEY": ("TMDB", "api_key"),
+        "LBSTATS_USERNAME": ("Letterboxd", "username"),
+        "LBSTATS_PASSWORD": ("Letterboxd", "password"),
+    }
+
+    for env_var, keys in env_mapping.items():
+        if env_var in os.environ:
+            section, key = keys
+            value = os.environ[env_var]
+            # Convert boolean strings to actual booleans
+            if value.lower() in ["true", "false"]:
+                value = value.lower() == "true"
+            elif value.isdigit():
+                value = int(value)
+            config[section][key] = value
+            
+            # Print a message indicating the environment variable is being used
+            print(f"Using environment variable {env_var} for config: {section}.{key} = {value}")
+        
+    return config
 
 parser = argparse.ArgumentParser(
     prog="Letterboxd Stats",
@@ -57,7 +89,7 @@ parser.add_argument("-L", "--lists", help="show lists", action="store_true")
 parser.add_argument("-l", "--limit", help="limit the number of items of your wishlist/diary", type=int)
 parser.add_argument("-c", "--config_folder", help="Specify the folder of your config.toml file")
 
-if len(sys.argv)==1:
+if len(sys.argv) == 1:
     parser.print_help(sys.stderr)
     sys.exit(1)
 
@@ -70,6 +102,6 @@ if not os.path.exists(config_path):
         f"Found no configuration file in {config_path}. "
         + "Please, add a config.toml in that folder or specify a custom one with the -c command."
     )
-    
+
 config = load_config(config_path, CONFIG_DEFAULTS)
 

--- a/letterboxd_stats/__init__.py
+++ b/letterboxd_stats/__init__.py
@@ -55,7 +55,7 @@ parser.add_argument("-D", "--diary", help="show diary", action="store_true")
 parser.add_argument("-R", "--ratings", help="show ratings", action="store_true")
 parser.add_argument("-L", "--lists", help="show lists", action="store_true")
 parser.add_argument("-l", "--limit", help="limit the number of items of your wishlist/diary", type=int)
-parser.add_argument("-c", "--config_folder", help="Specifiy the folder of your config.toml file")
+parser.add_argument("-c", "--config_folder", help="Specify the folder of your config.toml file")
 
 if len(sys.argv)==1:
     parser.print_help(sys.stderr)

--- a/letterboxd_stats/__init__.py
+++ b/letterboxd_stats/__init__.py
@@ -89,9 +89,9 @@ parser.add_argument("-L", "--lists", help="show lists", action="store_true")
 parser.add_argument("-l", "--limit", help="limit the number of items of your wishlist/diary", type=int)
 parser.add_argument("-c", "--config_folder", help="Specify the folder of your config.toml file")
 
-if len(sys.argv) == 1:
-    parser.print_help(sys.stderr)
-    sys.exit(1)
+#if len(sys.argv) == 1:
+#    parser.print_help(sys.stderr)
+#    sys.exit(1)
 
 args = parser.parse_args()
 

--- a/letterboxd_stats/cli.py
+++ b/letterboxd_stats/cli.py
@@ -100,7 +100,7 @@ def _validate_date(s: str) -> bool:
     return True
 
 
-def add_film_questions() -> dict[str, str]:
+def get_input_add_diary_entry() -> dict[str, str]:
     print("Set all the infos for the film:\n")
     specify_date = inquirer.confirm(message="Specify date?").execute()  # type: ignore
     today = datetime.today().strftime("%Y-%m-%d")

--- a/letterboxd_stats/cli.py
+++ b/letterboxd_stats/cli.py
@@ -20,14 +20,14 @@ def select_value(values: list[str], message: str, default: str | None = None) ->
     return value
 
 
-def select_movie(movies: pd.Series, results: pd.Series) -> str:
+def select_film(films: pd.Series, results: pd.Series) -> str:
     result = inquirer.fuzzy(  # type: ignore
-        message="Select movie for more information",
+        message="Select film for more information:",
         mandatory=False,
         max_height="25%",
-        choices=[Choice(value=result, name=title) for result, title in zip(results, movies)],
+        choices=[Choice(value=result, name=title) for result, title in zip(results, films)],
         keybindings={"skip": [{"key": "escape"}]},
-        invalid_message="Input not in list of movies.",
+        invalid_message="Input not in list of films.",
         validate=lambda result: result in results.values,
     ).execute()
     return result
@@ -121,7 +121,7 @@ def add_film_questions() -> dict[str, str]:
         replace_mode=True,
         filter=lambda n: int(2 * float(n)),
     ).execute()
-    liked = inquirer.confirm(message="Add to your ""Liked"" movies?").execute()  # type: ignore
+    liked = inquirer.confirm(message="Add to your ""Liked"" films?").execute()  # type: ignore
     review = inquirer.text(  # type: ignore
         message="Write a review. "
         + "Use HTML tags for formatting (<b>, <i>, <a href='[URL]'>, <blockquote<>). "

--- a/letterboxd_stats/cli.py
+++ b/letterboxd_stats/cli.py
@@ -121,13 +121,14 @@ def get_input_add_diary_entry() -> dict[str, str]:
         replace_mode=True,
         filter=lambda n: int(2 * float(n)),
     ).execute()
-    liked = inquirer.confirm(message="Add to your ""Liked"" films?").execute()  # type: ignore
+    liked = inquirer.confirm(message="Give this film a ♥?").execute()  # type: ignore
+    leave_review = inquirer.confirm(message="Leave a review?").execute()  # type: ignore
     review = inquirer.text(  # type: ignore
         message="Write a review. "
         + "Use HTML tags for formatting (<b>, <i>, <a href='[URL]'>, <blockquote<>). "
         + "Press Enter for multiline.",
         multiline=True,
-    ).execute()
+    ).execute() if leave_review else ""
     contains_spoilers = False
     if len(review) > 0:
         contains_spoilers = inquirer.confirm(message="The review contains spoilers?").execute()  # type: ignore

--- a/letterboxd_stats/data.py
+++ b/letterboxd_stats/data.py
@@ -99,7 +99,7 @@ def _show_lists(df: pd.DataFrame, ascending: bool) -> pd.DataFrame:
     avg = {"Rating Mean": "{:.2f}".format(df["Rating"].mean())}
     if config["TMDB"]["get_list_runtimes"] is True:
         ids = df["Url"].parallel_map(get_tmdb_id)
-        df["Duration"] = ids.parallel_map(lambda id: tmdb.get_film_duration(id))  # type: ignore
+        df["Duration"] = ids.parallel_map(lambda id: tmdb.get_movie_duration(id))  # type: ignore
         avg["Time-weighted Rating Mean"] = "{:.2f}".format(
             ((df["Duration"] / df["Duration"].sum()) * df["Rating"]).sum()
         )

--- a/letterboxd_stats/data.py
+++ b/letterboxd_stats/data.py
@@ -14,8 +14,8 @@ pandarallel.initialize(progress_bar=False, verbose=1)
 
 def check_if_watched(df: pd.DataFrame, row: pd.Series) -> bool:
     """watched.csv hasn't the TMDB id, so comparison can be done only by title.
-    This creates the risk of mismatch when two movies have the same title. To avoid this,
-    we must retrieve the TMDB id of the watched movie.
+    This creates the risk of mismatch when two films have the same title. To avoid this,
+    we must retrieve the TMDB id of the watched film.
     """
 
     if row["Title"] in df["Name"].values:
@@ -47,11 +47,11 @@ def read_watched_films(df: pd.DataFrame, path: str, name: str) -> pd.DataFrame:
 
 
 def select_film_of_person(df: pd.DataFrame) -> pd.Series | None:
-    movie_id = cli.select_movie(df["Title"], df.index.to_series())
-    if movie_id is None:
+    film_id = cli.select_film(df["Title"], df.index.to_series())
+    if film_id is None:
         return None
-    movie_row = df.loc[movie_id]
-    return movie_row
+    film_row = df.loc[film_id]
+    return film_row
 
 
 def get_list_name(path: str) -> str:
@@ -83,7 +83,7 @@ def open_file(filetype: str, path: str, limit, ascending, header=0) -> str:
     if limit is not None:
         df = df.iloc[:limit, :]
     cli.render_table(df, filetype)
-    return cli.select_movie(df["Title"], df["Url"])
+    return cli.select_film(df["Title"], df["Url"])
 
 
 def _show_lists(df: pd.DataFrame, ascending: bool) -> pd.DataFrame:

--- a/letterboxd_stats/data.py
+++ b/letterboxd_stats/data.py
@@ -59,14 +59,14 @@ def get_list_name(path: str) -> str:
     return df["Name"].iloc[0]
 
 
-def open_list(path: str, limit: int, acending: bool) -> str:
+def open_list(path: str, limit: int, ascending: bool) -> str:
     """Select a list from the saved ones."""
 
     list_names = {
         get_list_name(os.path.join(path, letterboxd_list)): letterboxd_list for letterboxd_list in os.listdir(path)
     }
     name = cli.select_list(sorted(list(list_names.keys())))
-    return open_file("Lists", os.path.join(path, list_names[name]), limit, acending, header=3)
+    return open_file("Lists", os.path.join(path, list_names[name]), limit, ascending, header=3)
 
 
 def open_file(filetype: str, path: str, limit, ascending, header=0) -> str:

--- a/letterboxd_stats/main.py
+++ b/letterboxd_stats/main.py
@@ -22,7 +22,7 @@ def check_path(path: str):
 
 
 def download_data():
-    """Download exported data you find in the import/esport section of your Letterboxd profile"""
+    """Download exported data you find in the import/export section of your Letterboxd profile"""
 
     connector = ws.Connector()
     connector.login()
@@ -37,7 +37,7 @@ def search_person(args_search: str):
     check_path(path)
     df = data.read_watched_films(df, path, name)
     movie = data.select_film_of_person(df)
-    # We want to print the link of the selected movie. This has to be retrived from the search page.
+    # We want to print the link of the selected movie. This has to be retrieved from the search page.
     while movie is not None:
         search_film_query = f"{movie['Title']} {movie['Release Date'].year}"  # type: ignore
         title_url = ws.get_lb_title(search_film_query)

--- a/letterboxd_stats/main.py
+++ b/letterboxd_stats/main.py
@@ -41,13 +41,13 @@ def search_person(args_search: str):
     while movie is not None:
         search_film_query = f"{movie['Title']} {movie['Release Date'].year}"  # type: ignore
         title_url = ws.get_lb_title(search_film_query)
-        tmdb.get_movie_detail(int(movie.name), ws.create_movie_url(title_url, "film_page"))  # type: ignore
+        tmdb.get_movie_detail(int(movie.name), ws.create_lb_url(title_url, "film_page"))  # type: ignore
         movie = data.select_film_of_person(df)
 
 
 def search_film(args_search_film: str):
     title_url = ws.get_lb_title(args_search_film, True)
-    film_url = ws.create_movie_url(title_url, "film_page")
+    film_url = ws.create_lb_url(title_url, "film_page")
     tmdb.get_movie_detail(ws.get_tmdb_id(film_url), film_url)  # type: ignore
     answer = ws.select_optional_operation()
     if answer != "Exit":

--- a/letterboxd_stats/main.py
+++ b/letterboxd_stats/main.py
@@ -24,9 +24,9 @@ def check_path(path: str):
 def download_data():
     """Download exported data you find in the import/esport section of your Letterboxd profile"""
 
-    downloader = ws.Downloader()
-    downloader.login()
-    downloader.download_stats()
+    connector = ws.Connector()
+    connector.login()
+    connector.download_stats()
 
 
 def search_person(args_search: str):
@@ -51,9 +51,9 @@ def search_film(args_search_film: str):
     tmdb.get_movie_detail(ws.get_tmdb_id(film_url), film_url)  # type: ignore
     answer = ws.select_optional_operation()
     if answer != "Exit":
-        downloader = ws.Downloader()
-        downloader.login()
-        downloader.perform_operation(answer, title_url)
+        connector = ws.Connector()
+        connector.login()
+        connector.perform_operation(answer, title_url)
 
 
 def display_data(args_limit: int, args_ascending: bool, data_type: str):

--- a/letterboxd_stats/main.py
+++ b/letterboxd_stats/main.py
@@ -1,7 +1,9 @@
+import os
+import sys
+
 from letterboxd_stats import tmdb
 from letterboxd_stats import data
 from letterboxd_stats import web_scraper as ws
-import os
 from letterboxd_stats import args, config
 
 DATA_FILES = {"Watchlist": "watchlist.csv", "Diary": "diary.csv", "Ratings": "ratings.csv", "Lists": "lists"}
@@ -74,20 +76,25 @@ def display_data(args_limit: int, args_ascending: bool, data_type: str):
 
 
 def main():
-    if args.download:
-        try_command(download_data, ())
-    if args.search:
-        try_command(search_person, (args.search,))
-    if args.search_film:
-        try_command(search_film, (args.search_film,))
-    if args.watchlist:
-        try_command(display_data, (args.limit, config["CLI"]["ascending"], "Watchlist"))
-    if args.diary:
-        try_command(display_data, (args.limit, config["CLI"]["ascending"], "Diary"))
-    if args.ratings:
-        try_command(display_data, (args.limit, config["CLI"]["ascending"], "Ratings"))
-    if args.lists:
-        try_command(display_data, (args.limit, config["CLI"]["ascending"], "Lists"))
+    try:
+        if args.download:
+            try_command(download_data, ())
+        if args.search:
+            try_command(search_person, (args.search,))
+        if args.search_film:
+            try_command(search_film, (args.search_film,))
+        if args.watchlist:
+            try_command(display_data, (args.limit, config["CLI"]["ascending"], "Watchlist"))
+        if args.diary:
+            try_command(display_data, (args.limit, config["CLI"]["ascending"], "Diary"))
+        if args.ratings:
+            try_command(display_data, (args.limit, config["CLI"]["ascending"], "Ratings"))
+        if args.lists:
+            try_command(display_data, (args.limit, config["CLI"]["ascending"], "Lists"))
+        
+    except KeyboardInterrupt:
+        print('\nProgram interrupted. Exiting.')
+        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/letterboxd_stats/main.py
+++ b/letterboxd_stats/main.py
@@ -30,19 +30,19 @@ def download_data():
 
 
 def search_person(args_search: str):
-    """Search for a director, list his/her movies and check if you have watched them."""
+    """Search for a director, list his/her films and check if you have watched them."""
 
     df, name = tmdb.get_person(args_search)
     path = os.path.expanduser(os.path.join(config["root_folder"], "static", "watched.csv"))
     check_path(path)
     df = data.read_watched_films(df, path, name)
-    movie = data.select_film_of_person(df)
-    # We want to print the link of the selected movie. This has to be retrieved from the search page.
-    while movie is not None:
-        search_film_query = f"{movie['Title']} {movie['Release Date'].year}"  # type: ignore
+    film = data.select_film_of_person(df)
+    # We want to print the link of the selected film. This has to be retrieved from the search page.
+    while film is not None:
+        search_film_query = f"{film['Title']} {film['Release Date'].year}"  # type: ignore
         title_url = ws.get_lb_title(search_film_query)
-        tmdb.get_movie_detail(int(movie.name), ws.create_lb_url(title_url, "film_page"))  # type: ignore
-        movie = data.select_film_of_person(df)
+        tmdb.get_movie_detail(int(film.name), ws.create_lb_url(title_url, "film_page"))  # type: ignore
+        film = data.select_film_of_person(df)
 
 
 def search_film(args_search_film: str):
@@ -66,7 +66,7 @@ def display_data(args_limit: int, args_ascending: bool, data_type: str):
         if data_type != "Lists"
         else data.open_list(path, args_limit, args_ascending)
     )
-    # If you select a movie, show its details.
+    # If you select a film, show its details.
     if letterboxd_url is not None:
         id = ws.get_tmdb_id(letterboxd_url, data_type == "diary")
         if id is not None:

--- a/letterboxd_stats/tmdb.py
+++ b/letterboxd_stats/tmdb.py
@@ -31,7 +31,7 @@ def get_person(name: str) -> Tuple[pd.DataFrame, str]:
     p = person.details(search_result["id"])
     known_for_department = p["known_for_department"]
     movie_credits = person.movie_credits(search_result["id"])
-    list_of_films = [
+    list_of_movies = [
         {
             "Id": m.id,
             "Title": m.title,
@@ -40,9 +40,9 @@ def get_person(name: str) -> Tuple[pd.DataFrame, str]:
         }
         for m in movie_credits["crew"]
     ]
-    if len(list_of_films) == 0:
+    if len(list_of_movies) == 0:
         raise ValueError("The selected person doesn't have any film.")
-    df = pd.DataFrame(list_of_films).set_index("Id")
+    df = pd.DataFrame(list_of_movies).set_index("Id")
     department = cli.select_value(
         df["Department"].unique(), f"Select a department for {p['name']}", known_for_department
     )
@@ -51,7 +51,7 @@ def get_person(name: str) -> Tuple[pd.DataFrame, str]:
     # person.details provides movies without time duration. If the user wants<S-D-A>
     # (since this slows down the process) get with the movie.details API.
     if config["TMDB"]["get_list_runtimes"] is True:
-        df["Duration"] = df.index.to_series().parallel_map(get_film_duration)  # type: ignore
+        df["Duration"] = df.index.to_series().parallel_map(get_movie_duration)  # type: ignore
     return df, p["name"]
 
 
@@ -84,8 +84,8 @@ def get_movie_detail(movie_id: int, letterboxd_url=None):
     cli.print_film(selected_details)
 
 
-def get_film_duration(tmdb_id: int) -> int:
-    """Get film duration from the TMDB api.
+def get_movie_duration(tmdb_id: int) -> int:
+    """Get movie duration from the TMDB api.
     https://developer.themoviedb.org/reference/movie-details
     """
 

--- a/letterboxd_stats/tmdb.py
+++ b/letterboxd_stats/tmdb.py
@@ -25,7 +25,7 @@ def get_person(name: str) -> Tuple[pd.DataFrame, str]:
     search_results = search.people({"query": name})
     names = [result.name for result in search_results]  # type: ignore
     if len(names) == 0:
-        raise Exception("No results for your search")
+        raise Exception("No results found for your TMDB person search.")
     result_index = cli.select_search_result(names)  # type: ignore
     search_result = search_results[result_index]
     p = person.details(search_result["id"])
@@ -60,7 +60,7 @@ def get_movie(movie_query: str) -> Any | AsObj:
     search_results = search.movies({"query": movie_query})
     titles = [f"{result.title} ({result.release_date})" for result in search_results]  # type: ignore
     if len(titles) == 0:
-        raise Exception("No results for your search")
+        raise Exception("No results found for your TMDB movie search.")
     result_index = cli.select_search_result(titles)  # type: ignore
     movie_id = search_results[result_index]["id"]
     get_movie_detail(movie_id)

--- a/letterboxd_stats/web_scraper.py
+++ b/letterboxd_stats/web_scraper.py
@@ -62,7 +62,7 @@ class Connector:
         os.remove(archive)
 
     def add_diary_entry(self, title: str):
-        payload = cli.add_film_questions()
+        payload = cli.get_input_add_diary_entry()
         url = create_lb_url(title, "diary")
         res = self.session.get(url)
         if res.status_code != 200:

--- a/letterboxd_stats/web_scraper.py
+++ b/letterboxd_stats/web_scraper.py
@@ -66,7 +66,7 @@ class Connector:
         url = create_lb_url(title, "diary")
         res = self.session.get(url)
         if res.status_code != 200:
-            raise ConnectionError("It's been impossible to retireve the Letterboxd page")
+            raise ConnectionError("It's been impossible to retrieve the Letterboxd page")
         movie_page = html.fromstring(res.text)
         # Not the TMDB id, but the Letterboxd ID to use to add the movie to diary.
         # Reference: https://letterboxd.com/film/seven-samurai/
@@ -110,7 +110,7 @@ def create_lb_url(title: str, operation: str) -> str:
 
 def _get_tmdb_id_from_web(link: str, is_diary: bool) -> int:
     """Scraping the TMDB link from a Letterboxd film page.
-    Inpect this HTML for reference: https://letterboxd.com/film/seven-samurai/
+    Inspect this HTML for reference: https://letterboxd.com/film/seven-samurai/
     """
 
     res = requests.get(link)
@@ -167,9 +167,9 @@ def get_lb_title(title: str, allow_selection=False) -> str:
     search_url = create_lb_url(title, "search")
     res = requests.get(search_url)
     if res.status_code != 200:
-        raise ConnectionError("It's been impossible to retireve the Letterboxd page")
+        raise ConnectionError("It's been impossible to retrieve the Letterboxd page")
     search_page = html.fromstring(res.text)
-    # If we want to select movies from the seach page, get more data to print the selection prompt.
+    # If we want to select movies from the search page, get more data to print the selection prompt.
     if allow_selection:
         movie_list = search_page.xpath("//div[@class='film-detail-content']")
         if len(movie_list) == 0:

--- a/letterboxd_stats/web_scraper.py
+++ b/letterboxd_stats/web_scraper.py
@@ -26,7 +26,7 @@ OPERATIONS_URLS = {
 cache_path = os.path.expanduser(os.path.join(config["root_folder"], "static", "cache.db"))
 
 
-class Downloader:
+class Connector:
     def __init__(self):
         self.session = requests.Session()
         # get home page to set cookies in the session.

--- a/letterboxd_stats/web_scraper.py
+++ b/letterboxd_stats/web_scraper.py
@@ -120,6 +120,12 @@ def _get_tmdb_id_from_web(link: str, is_diary: bool) -> int:
     tmdb_link = film_page.xpath("//a[@data-track-action='TMDb']")
     if len(tmdb_link) == 0:
         raise ValueError("No link found for film")
+    
+    tmdb_category = tmdb_link[0].get("href").split("/")[-3]
+    
+    if tmdb_category != "movie":
+        raise ValueError(f"Tool does not currently support TMDB category \"{tmdb_category}\": {tmdb_link[0].get("href")}")
+
     id = tmdb_link[0].get("href").split("/")[-2]
     return int(id)
 

--- a/letterboxd_stats/web_scraper.py
+++ b/letterboxd_stats/web_scraper.py
@@ -75,12 +75,6 @@ class Connector:
         payload["__csrf"] = self.session.cookies.get("com.xk72.webparts.csrf")
         res = self.session.post(ADD_DIARY_URL, data=payload)
         if not (res.status_code == 200 and res.json()["result"] is True):
-            error_details = (
-                f"Error during POST request to {ADD_DIARY_URL}\n"
-                f"Status Code: {res.status_code}\n"
-                f"Response Content: {res.text}\n"
-                f"Payload: {payload}\n"
-            )
             raise ConnectionError(f"Failed to add to diary.")
         print(f"{title} was added to your diary.")
 

--- a/letterboxd_stats/web_scraper.py
+++ b/letterboxd_stats/web_scraper.py
@@ -98,10 +98,10 @@ class Connector:
             raise ConnectionError("Remove from watchlist request failed.")
         print("Removed to your watchlist.")
 
-    def perform_operation(self, answer: str, link: str):
+    def perform_operation(self, operation: str, link: str):
         """Depending on what the user has chosen, add to diary, add/remove watchlist."""
 
-        getattr(self, MOVIE_OPERATIONS[answer])(link)
+        getattr(self, MOVIE_OPERATIONS[operation])(link)
 
 
 def create_lb_url(title: str, operation: str) -> str:

--- a/letterboxd_stats/web_scraper.py
+++ b/letterboxd_stats/web_scraper.py
@@ -124,7 +124,8 @@ def _get_tmdb_id_from_web(link: str, is_diary: bool) -> int:
     tmdb_category = tmdb_link[0].get("href").split("/")[-3]
     
     if tmdb_category != "movie":
-        raise ValueError(f"Tool does not currently support TMDB category \"{tmdb_category}\": {tmdb_link[0].get("href")}")
+        full_link = tmdb_link[0].get("href")
+        raise ValueError(f"Tool does not currently support TMDB category \"{tmdb_category}\": {full_link}")
 
     id = tmdb_link[0].get("href").split("/")[-2]
     return int(id)


### PR DESCRIPTION
### ❗❗ I accidentally closed [this PR](https://github.com/mBaratta96/letterboxd_stats/pull/62) when renaming my branch. Sorry for the multiple pings on this. 

# Environment Variable Support + Small Fixes and Renaming
I hope you'll find that these changes make the code slightly easier to understand at first glance, and add some things behind the scenes for developers working on this project that will make the process a bit smoother. I also used a plugin to find any typos and did some other housekeeping stuff. Hopefully you don't mind!

## Changes
### Large-ish
- Added support for environment variables to override (or just alternatively supply if they are missing) values from the config. Should make it simpler to run this in virtual environments without setting up a config in the proper location. [#](https://github.com/mBaratta96/letterboxd_stats/pull/62/commits/2fb18e2db02fbc001fdf27eb3f8dca690a89ff66)

### Medium
- Prevent looking up non-movies on TMDB. Addresses [this issue.](https://github.com/mBaratta96/letterboxd_stats/issues/63) Throws error if TMDB type is not 'movie'. [#](https://github.com/mBaratta96/letterboxd_stats/pull/62/commits/3483e9768bd1d04b5fc90fd32dc60aaa3961d3c7)
- Standardized the use of "film" and "movie" so film is used everywhere EXCEPT when referring to TMDB. Before they were used somewhat randomly. _Alternatively you could use "movie" everywhere internally except where Letterboxd uses "film"._ [#](https://github.com/mBaratta96/letterboxd_stats/pull/62/commits/4c199934fa00d2609eb26ae7d1978b4422a6c53a) [#](https://github.com/mBaratta96/letterboxd_stats/pull/62/commits/a098a63d91375a23fe9bbfb899afaaf4617f08a0)

### Small
 - Renamed "Downloader" class to "Connector" class, now that is is not just used for downloading. [#](https://github.com/mBaratta96/letterboxd_stats/pull/62/commits/de70a180769ecf07122b1a41143563b006c3db44)
 - Renamed some functions. [#](https://github.com/mBaratta96/letterboxd_stats/pull/62/commits/79a12389142f4e4fdb5ce184648ff4e4afaa5092) [#](https://github.com/mBaratta96/letterboxd_stats/pull/62/commits/db22dece3ed7e1695713017dd0bf0b5e1e2ce8b0)
 - Renamed some function parameters. [#](https://github.com/mBaratta96/letterboxd_stats/pull/62/commits/40bc08b789ddcb114c05c3a315035cb0680a565f)
 - Update some CLI-input user-prompts to streamline UX. [#](https://github.com/mBaratta96/letterboxd_stats/pull/62/commits/802372562517b47e448797e6ba8fec6f2391c7f9)
 - Standardized structure of error messages for the same type of error. [#](https://github.com/mBaratta96/letterboxd_stats/pull/62/commits/0d04dab23cbea49340e51dd61e89ed32af991e27)
 - Updated the License with the year and name of the owner. [#](https://github.com/mBaratta96/letterboxd_stats/pull/62/commits/6f0732aa86a433e5f68fd159a86f5d98f36a2012)
 - Updated the gitignore and added comments, and cspell folder. [#](https://github.com/mBaratta96/letterboxd_stats/pull/62/commits/03973a7dff220f5ba5e3e5a24cd36b62032d2996)
 - Corrected spelling errors using the cspell extension. [#](https://github.com/mBaratta96/letterboxd_stats/pull/62/commits/aff6c15eac4f8ab41ef8c7b7e221c10ccafde3e6)


## Future Work
### Working towards...
- Splitting the Letterboxd interactions from the CLI, so the CLI acts like a frontend for a separate backend. This will improve modularity and will expose more functions that can be used when calling letterboxd_stats as a python library. 
